### PR TITLE
Era3

### DIFF
--- a/Core.ars
+++ b/Core.ars
@@ -862,6 +862,7 @@ Trait core.capitalTradeDesignation {
 		{ type:core.trillumExtractor alloc:demand }
 
 		{ type:core.imperialAdministration alloc:demand }
+		{ type:core.militiaBase alloc:fixed allocValue:10.0 }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
@@ -1008,6 +1009,7 @@ Trait core.sectorCapitalTradeDesignation {
 		{ type:core.trillumExtractor alloc:demand }
 
 		{ type:core.sectorCapitalAdministration alloc:demand }
+		{ type:core.militiaBase alloc:fixed allocValue:10.0 }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
@@ -1043,6 +1045,7 @@ Trait core.tradingHubDesignation {
 		{ type:core.trillumExtractor alloc:demand }
 
 		{ type:core.imperialAdministration alloc:demand }
+		{ type:core.militiaBase alloc:fixed allocValue:5.0 }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 

--- a/CoreDefenses.ars
+++ b/CoreDefenses.ars
@@ -150,7 +150,7 @@ ResourceType core.hypersonicMissile
 	{
 	category: fixedUnit
 	name: "hypersonic missile site"
-	attackValue: 53				//	presumably this would need to be updated too, but IDK the equation
+	attackValue: 53					//	presumably this would need to be updated too, but IDK the equation
 	mass: 200.0
 	halfLife: 3.0
 

--- a/CoreDefenses.ars
+++ b/CoreDefenses.ars
@@ -112,9 +112,8 @@ ResourceType core.GDM
 	attackValue: 29
 	mass: 200.0
 	halfLife: 2.0
-	isExpendable: true
 
-	attack: { name:"nuclear warhead" count:1 damage:32 type:missile strength:1 range:15.0 area:0.2 }
+	attack: { name:"nuclear warhead" count:1 damage:32 type:missile strength:1 range:10.0 area:0.2 }
 	defense: { armor:16 }
 
 	production: {
@@ -151,11 +150,11 @@ ResourceType core.hypersonicMissile
 	{
 	category: fixedUnit
 	name: "hypersonic missile site"
-	attackValue: 53
+	attackValue: 53				//	presumably this would need to be updated too, but IDK the equation
 	mass: 200.0
 	halfLife: 3.0
 
-	attack: { name:"H2 interceptor" count:1 damage:48 type:missile strength:2 range:25.0 area:0.2 }
+	attack: { name:"H2 interceptor" count:1 damage:48 type:missile strength:2 range:20.0 area:0.2 }
 	defense: { armor:128 }
 
 	production: {

--- a/CoreJumpships.ars
+++ b/CoreJumpships.ars
@@ -108,7 +108,7 @@ ResourceType core.explorerVanguard {
 	maxDeltaV: 2.0							//	In km/sec
 	scanner: 1.0
 	visibility: 0.02
-	halfLife: 5.0
+	halfLife: 4.0
 
 	attack: { name:"laser cannon" count:1 damage:2 type:direct range:5.0 area:0.0 }
 	defense: { armor:4 }

--- a/CoreRamships.ars
+++ b/CoreRamships.ars
@@ -88,8 +88,8 @@ ResourceType core.gunshipHammerhead {
 	visibility: 0.10
 	halfLife: 10.0
 
-	attack: { name:"AX1 missile" count:1 damage:48 type:missile strength:1 range:5.0 area:0.0 }
-	defense: { armor:120 counters:{ missile:1 } }
+	attack: { name:"AX1 recoilless cannon" count:1 damage:48 type:direct range:10.0 area:0.0 }
+	defense: { armor:120 }
 	unitsPerCell: 16
 
 	production: {
@@ -115,7 +115,7 @@ ResourceType core.starfrigateManta {
 	visibility: 2.0
 	halfLife: 20.0
 
-	attack: { name:"Tholin particle cannon" count:1 damage:96 type:direct range:15.0 area:0.0 }
+	attack: { name:"Tholin particle cannon" count:1 damage:144 type:direct range:15.0 area:0.1 }
 	defense: { armor:240 counters:{ missile:1 } }
 	unitsPerCell: 2
 
@@ -173,8 +173,8 @@ ResourceType core.gunshipCerberus {
 	visibility: 0.20
 	halfLife: 10.0
 
-	attack: { name:"Trident cannon" count:1 damage:96 type:direct range:10.0 area:0.1 }
-	defense: { armor:240 counters:{ missile:1 } }
+	attack: { name:"Trident cannon" count:1 damage:96 type:direct range:15.0 area:0.1 }
+	defense: { armor:240 }
 	unitsPerCell: 16
 
 	production: {

--- a/CoreRamships.ars
+++ b/CoreRamships.ars
@@ -80,7 +80,7 @@ ResourceType core.gunshipHammerhead {
 	category: maneuveringUnit
 	name: "Hammerhead-class gunship"
 	role: gunship
-	attackValue: 70
+	attackValue: 70				//	May need to be recalculated
 	FTL: { type:ramjet speed:3.0 }
 	mass: 10.0
 	maxDeltaV: 1.0
@@ -107,7 +107,7 @@ ResourceType core.starfrigateManta {
 	category: maneuveringUnit
 	name: "Manta-class starfrigate"
 	role: starfrigate
-	attackValue: 914
+	attackValue: 914			//	May need to be recalculated
 	FTL: { type:ramjet speed:1.0 }
 	mass: 200.0
 	maxDeltaV: 0.2
@@ -165,7 +165,7 @@ ResourceType core.gunshipCerberus {
 	category: maneuveringUnit
 	name: "Cerberus-class gunship"
 	role: gunship
-	attackValue: 180
+	attackValue: 180			//	May need to be recalculated
 	FTL: { type:ramjet speed:5.0 }
 	mass: 20.0
 	maxDeltaV: 1.0

--- a/CoreStarships.ars
+++ b/CoreStarships.ars
@@ -111,7 +111,7 @@ ResourceType core.starfrigateDefiance {
 	visibility: 1.1
 	halfLife: 20.0
 
-	attack: { name:"positron lancer" count:1 damage:64 type:direct range:20.0 area:0.1 }
+	attack: { name:"positron lancer" count:1 damage:96 type:direct range:20.0 area:0.1 }
 	defense: { armor:160 counters:{ missile:1 } }
 	unitsPerCell: 2
 
@@ -168,7 +168,7 @@ ResourceType core.gunshipMinotaur {
 	maxDeltaV: 1.75
 	scanner: 0.1
 	visibility: 0.12
-	halfLife: 12.0
+	halfLife: 10.0
 
 	attack: { name:"slam cannon" count:1 damage:64 type:direct range:15.0 area:0.0 }
 	defense: { armor:160 }

--- a/CoreStarships.ars
+++ b/CoreStarships.ars
@@ -103,7 +103,7 @@ ResourceType core.starfrigateDefiance {
 	category: maneuveringUnit
 	name: "Defiance-class starfrigate"
 	role: starfrigate
-	attackValue: 1017
+	attackValue: 1017		//	May need to be recalculated
 	FTL: 0.2
 	mass: 110.0
 	maxDeltaV: 0.25
@@ -162,7 +162,7 @@ ResourceType core.gunshipMinotaur {
 	category: maneuveringUnit
 	name: "Minotaur-class gunship"
 	role: gunship
-	attackValue: 145
+	attackValue: 145		//	May need to be recalculated
 	FTL: 5.0
 	mass: 12.0
 	maxDeltaV: 1.75

--- a/FallenWorlds.ars
+++ b/FallenWorlds.ars
@@ -122,10 +122,6 @@ SovereignType core.playerEmpire
 			{	type: core.jumptransportReliant
 				value: { type:gaussian	median:2000		low:75		high:150	}
 				}
-					
-			{	type: core.jumpshipStinger
-				value: { type:gaussian	median:1000		low:75		high:150	}
-				}
 				
 			{	type: core.jumpshipStinger
 				value: { type:gaussian	median:2500		low:75		high:150	}

--- a/FallenWorlds.ars
+++ b/FallenWorlds.ars
@@ -18,11 +18,11 @@ Scenario fallenWorlds.scenario
 	creation: (
 
 		//	Create worlds suitable for player capitals
-		
+		//	Note: this creates earthlike worlds in bright nebula zones, where they would normally be prohibited
 		{ create:worlds
 			count:100
 			
-			region:sectorRegion 
+			region:sectorRegion 	
 			minDist:200
 			minEdgeDist:100
 			
@@ -126,6 +126,14 @@ SovereignType core.playerEmpire
 			{	type: core.jumpshipStinger
 				value: { type:gaussian	median:1000		low:75		high:150	}
 				}
+				
+			{	type: core.jumpshipStinger
+				value: { type:gaussian	median:2500		low:75		high:150	}
+				}
+			
+			{	type: core.jumpcruiserAdamant
+				value: { type:gaussian	median:750		low:75		high:150	}
+				}				
 			)
 		}
 


### PR DESCRIPTION
Implemented forum-requested changes to era3, based on the list at https://forums.kronosaur.com/viewtopic.php?f=48&t=8097&p=72992#p72982.

Also added the militia base structure to trade hubs and T&E capitals/sector capitals to stop Mesophon and T&E players from being totally defenseless against ground invasion; if this creates problems ignore the request. WUs are still wasted on these worlds, a more elegant solution would be to have the militia base get alloc:max (IDK if removing all labor from the starport creates problems) or to have the starport structure be able to build some kind of infantry directly.

Some attackValues may need to be updated, I do not know the equation that determines these.

Mesophon ship prices, which are not part of the library, should be revised at some point since they are based on obsolete era2 power values.