### PR TITLE
Minor fixes

### DIFF
--- a/Core.ars
+++ b/Core.ars
@@ -306,6 +306,9 @@ Trait core.sectorCapitalAdministration {
 	minTechLevel: 5
 	buildTime: 1440
 
+	//	Any world that is part of an empire rises to at least level 5
+	techLevelAdj: { value:5.0	op:min }
+
 	designationOnly: true
 	workingConditions: 10
 	}

--- a/Core.ars
+++ b/Core.ars
@@ -237,7 +237,7 @@ Trait core.pressurizedHabitat {
 
 	workingConditions: 6
 
-	description: "A pressurized habit is an upgrade to a life support system. A pressurize habitat allows a larger population to survive on a barren world."
+	description: "A pressurized habit is an upgrade to a life support system. A pressurized habitat allows a larger population to survive on a barren world."
 	}
 
 Trait core.pressurizedHabitatRuins {
@@ -610,7 +610,7 @@ Trait core.fusionProgram {
 
 	workingConditions: 9
 
-	description: "This program advances the world to fusion tech level."
+	description: "This program advances the world to fusion tech level but consumes 5% of its labor output."
 	}
 
 Trait core.biotechProgram {
@@ -628,11 +628,11 @@ Trait core.biotechProgram {
 
 	workingConditions: 9
 
-	description: "This program advances the world to biotech level."
+	description: "This program advances the world to biotech level but consumes 10% of its labor output. Programs cannot advance a world beyond biotech level."
 	}
 
 Trait core.antimatterProgram {
-	name: "antimatter program"
+	name: "antimatter megaprogram"
 	category: improvement
 	role: techAdvance
 
@@ -646,11 +646,11 @@ Trait core.antimatterProgram {
 
 	workingConditions: 9
 
-	description: "This program advances the capital to antimatter tech level."
+	description: "This program advances the capital to antimatter tech level but consumes 5% of its labor output."
 	}
 
 Trait core.quantumProgram {
-	name: "quantum program"
+	name: "quantum megaprogram"
 	category: improvement
 	role: techAdvance
 
@@ -664,11 +664,11 @@ Trait core.quantumProgram {
 
 	workingConditions: 9
 
-	description: "This program advances the capital to quantum tech level."
+	description: "This program advances the capital to quantum tech level but consumes 10% of its labor output."
 	}
 
 Trait core.postIndustrialProgram {
-	name: "post-industrial program"
+	name: "post-industrial megaprogram"
 	category: improvement
 	role: techAdvance
 
@@ -682,7 +682,7 @@ Trait core.postIndustrialProgram {
 
 	workingConditions: 9
 
-	description: "This program advances the capital to post-industrial tech level."
+	description: "This program advances the capital to post-industrial tech level but consumes 15% of its labor output."
 	}
 
 //	Designations ---------------------------------------------------------------

--- a/CoreDefenses.ars
+++ b/CoreDefenses.ars
@@ -221,7 +221,9 @@ Trait core.armoredConstellation {
 	minTechLevel: 7
 	buildUpgrade: (core.autocannonConstellation)
 	buildTime: 30
+	destroysTo: (core.autocannonConstellation)
 	createsResourcesOnGameCreate: true
+	
 
 	workingConditions: 5
 
@@ -256,6 +258,7 @@ Trait core.battlestationProgram {
 	minTechLevel: 9
 	buildUpgrade: (core.armoredConstellation)
 	buildTime: 480
+	destroysTo: (core.armoredConstellation)
 	createsResourcesOnGameCreate: true
 
 	workingConditions: 5
@@ -323,6 +326,7 @@ Trait core.HMComplex {
 	minTechLevel: 6
 	buildUpgrade: (core.GDMComplex)
 	buildTime: 15
+	destroysTo: (core.GDMComplex)
 	createsResourcesOnGameCreate: true
 
 	workingConditions: 5
@@ -341,6 +345,8 @@ Trait core.plasmaTowerNetwork {
 	minTechLevel: 8
 	buildUpgrade: (core.HELCannonNetwork)
 	buildTime: 120
+	destroysTo: (core.HELCannonNetwork)
+
 	createsResourcesOnGameCreate: true
 
 	workingConditions: 5

--- a/CoreDefenses.ars
+++ b/CoreDefenses.ars
@@ -225,7 +225,7 @@ Trait core.armoredConstellation {
 
 	workingConditions: 5
 
-	description: "This improvement upgrades the satellites of an autocannon constellation with armored and heavily armed satellites. Each armored satellite is equipped with powerful H5 missiles."
+	description: "This improvement gradually replaces the satellites of an autocannon constellation with armored and heavily armed satellites. Each armored satellite is equipped with powerful H5 missiles."
 	}
 	
 Trait core.autocannonConstellation {
@@ -242,7 +242,7 @@ Trait core.autocannonConstellation {
 
 	workingConditions: 5
 
-	description: "An autocannon constellation is a network of laser-equipped satellites. It is designed to repel a landing force of lightly armed transports."
+	description: "An autocannon constellation is a network of laser-equipped satellites. Individual satellites are more costly than ground-based defenses but have a longer operational lifespan; constellations are a long-term investment."
 	}
 	
 Trait core.battlestationProgram {
@@ -292,7 +292,7 @@ Trait core.GDMComplex {
 
 	workingConditions: 5
 
-	description: "Nuclear-tipped ground defense missiles (GDMs) are cheap but deadly defenses for underdeveloped worlds. Each GDM site contains a single missile, which is expended on use."
+	description: "Nuclear-tipped ground defense missiles (GDMs) are cheap but deadly defenses for underdeveloped worlds. GDMs are effective against low-tech attackers but can be neutralized by ships with point defense, such as Stinger-class jumpships."
 	}
 	
 Trait core.HELCannonNetwork {
@@ -327,7 +327,7 @@ Trait core.HMComplex {
 
 	workingConditions: 5
 
-	description: "This improvement builds a complex of hypersonic missile sites capable of attacking enemy ships in orbit. Each site can fire an unlimited number of missiles during a conflict."
+	description: "This improvement builds a complex of hypersonic missile sites capable of attacking enemy ships in high orbit."
 	}
 	
 Trait core.plasmaTowerNetwork {

--- a/CoreEnvironment.ars
+++ b/CoreEnvironment.ars
@@ -87,6 +87,8 @@ Trait core.aetherealWorld
 				)
 			}
 
+		core.hexacarbideRare
+
 		{	type:table
 			value: (
 				(60		core.trillumCommon)
@@ -94,8 +96,6 @@ Trait core.aetherealWorld
 				(10		core.trillumRare)
 				)
 			}
-
-		core.hexacarbideRare
 
 		core.airProcessor
 		)
@@ -200,6 +200,14 @@ Trait core.chthonicWorld
 
 		{	type:table
 			value: (
+				(60		core.chtholonAbundant)
+				(30		core.chtholonCommon)
+				(10		core.chtholonUncommon)
+				)
+			}
+
+		{	type:table
+			value: (
 				(60		core.aetheriumRare)
 				(30		core.aetheriumUncommon)
 				(10		core.hexacarbideCommon)
@@ -211,14 +219,6 @@ Trait core.chthonicWorld
 				(60		core.chronimiumCommon)
 				(30		core.chronimiumUncommon)
 				(10		core.chronimiumRare)
-				)
-			}
-
-		{	type:table
-			value: (
-				(60		core.chtholonAbundant)
-				(30		core.chtholonCommon)
-				(10		core.chtholonUncommon)
 				)
 			}
 
@@ -374,20 +374,20 @@ Trait core.empyrealWorld
 	
 	impartTraits: (
 		core.desertBiosphere
+		
+		{	type:table
+			value: (
+				(60		core.chtholonAbundant)
+				(30		core.chtholonCommon)
+				(10		core.chtholonUncommon)
+				)
+			}
 
 		{	type:table
 			value: (
 				(60		core.aetheriumCommon)
 				(30		core.aetheriumUncommon)
 				(10		core.aetheriumAbundant)
-				)
-			}
-
-		{	type:table
-			value: (
-				(60		core.chtholonAbundant)
-				(30		core.chtholonCommon)
-				(10		core.chtholonUncommon)
 				)
 			}
 
@@ -447,6 +447,14 @@ Trait core.fieryWorld
 	impartTraits: (
 		{	type:table
 			value: (
+				(60		core.chronimiumRare)
+				(30		core.chronimiumUncommon)
+				(10		core.chronimiumCommon)
+				)
+			}
+
+		{	type:table
+			value: (
 				(60		core.hexacarbideRare)
 				(30		core.hexacarbideUncommon)
 				(10		core.hexacarbideCommon)
@@ -458,14 +466,6 @@ Trait core.fieryWorld
 				(60		core.trillumCommon)
 				(30		core.trillumUncommon)
 				(10		core.trillumAbundant)
-				)
-			}
-
-		{	type:table
-			value: (
-				(60		core.chronimiumRare)
-				(30		core.chronimiumUncommon)
-				(10		core.chronimiumCommon)
 				)
 			}
 
@@ -603,17 +603,17 @@ Trait core.hadeanWorld
 
 		{	type:table
 			value: (
-				(60		core.aetheriumCommon)
-				(30		core.aetheriumUncommon)
-				(10		core.aetheriumAbundant)
+				(60		core.chtholonCommon)
+				(30		core.chtholonUncommon)
+				(10		core.chtholonAbundant)
 				)
 			}
 
 		{	type:table
 			value: (
-				(60		core.chtholonCommon)
-				(30		core.chtholonUncommon)
-				(10		core.chtholonAbundant)
+				(60		core.aetheriumCommon)
+				(30		core.aetheriumUncommon)
+				(10		core.aetheriumAbundant)
 				)
 			}
 
@@ -669,17 +669,17 @@ Trait core.nebularWorld
 
 		{	type:table
 			value: (
-				(60		core.aetheriumRare)
-				(30		core.aetheriumUncommon)
-				(10		core.aetheriumCommon)
+				(60		core.chtholonCommon)
+				(30		core.chtholonUncommon)
+				(10		core.chtholonAbundant)
 				)
 			}
 
 		{	type:table
 			value: (
-				(60		core.chtholonCommon)
-				(30		core.chtholonUncommon)
-				(10		core.chtholonAbundant)
+				(60		core.aetheriumRare)
+				(30		core.aetheriumUncommon)
+				(10		core.aetheriumCommon)
 				)
 			}
 


### PR DESCRIPTION
- Revised a few defense descriptions (example: GDMs are no longer single shot)
- Revised tech program descriptions to be more explicit. Renamed the special capital programs "megaprograms" (in descriptive text only) so that players will not expect them to be buildable on other worlds.
- Add techLevelAdj to core.sectorCapitalAdministration to make sector capital fatedTL reversion consistent with all other worlds (which use the core.imperialAdministration structure).
- Defense structures destroy to the lower-TL structures they buildUpgrade from
- Standardize order that resource deposits are listed on planets in the overview tab (proposal changes the order to consistently be tri-hex-chr-aet-chth for all planet classes)
