### PR TITLE
Jumpbeacon build times on yards/SC; T&E gets beacons; other minor changes

### DIFF
--- a/Core.ars
+++ b/Core.ars
@@ -479,8 +479,9 @@ Trait core.starport {
 	maxTradeDist: { value:100.0 op:defaultValue }
 
 	minTechLevel: 5
-
-	designationOnly: true
+	destroysTo: (core.spaceport)
+	
+	esignationOnly: true
 	workingConditions: 7
 
 	description: "A starport is an upgraded spaceport that supports inter-empire trade."

--- a/Core.ars
+++ b/Core.ars
@@ -128,6 +128,24 @@ Trait core.imperialAdministration {
 	workingConditions: 10
 	}
 
+Trait core.jumpBeaconStructure {
+	name: "jumpbeacon"
+	category: improvement
+	inheritFrom: (core.jumpBeaconAttribute)
+
+	buildTime: 720
+
+	designationOnly: true
+	}
+
+Trait core.jumpBeaconCapitalStructure {
+	name: "jumpbeacon"
+	category: improvement
+	inheritFrom: (core.jumpBeaconAttribute)
+
+	designationOnly: true
+	}
+
 Trait core.neuralProcessor
 	{
 	name: "neural processor"
@@ -766,6 +784,7 @@ Trait core.capitalJumpshipDesignation {
 
 		{ type:core.imperialAdministration alloc:demand }
 		{ type:core.spaceport alloc:demand }
+		{ type:core.jumpBeaconCapitalStructure alloc:demand }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
@@ -867,6 +886,7 @@ Trait core.capitalTradeDesignation {
 
 		{ type:core.imperialAdministration alloc:demand }
 		{ type:core.militiaBase alloc:fixed allocValue:10.0 }
+		{ type:core.jumpBeaconCapitalStructure alloc:demand }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
@@ -902,6 +922,7 @@ Trait core.sectorCapitalDesignation {
 		{ type:core.trillumExtractor alloc:demand }
 
 		{ type:core.sectorCapitalAdministration alloc:demand }
+		{ type:core.jumpBeaconStructure alloc:demand }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
@@ -1014,6 +1035,7 @@ Trait core.sectorCapitalTradeDesignation {
 
 		{ type:core.sectorCapitalAdministration alloc:demand }
 		{ type:core.militiaBase alloc:fixed allocValue:10.0 }
+		{ type:core.jumpBeaconStructure alloc:demand }
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 

--- a/Core.ars
+++ b/Core.ars
@@ -129,7 +129,7 @@ Trait core.imperialAdministration {
 	}
 
 Trait core.jumpBeaconStructure {
-	name: "jumpbeacon"
+	name: "jump beacon"
 	category: improvement
 	inheritFrom: (core.jumpBeaconAttribute)
 
@@ -139,7 +139,7 @@ Trait core.jumpBeaconStructure {
 	}
 
 Trait core.jumpBeaconCapitalStructure {
-	name: "jumpbeacon"
+	name: "jump beacon"
 	category: improvement
 	inheritFrom: (core.jumpBeaconAttribute)
 
@@ -928,7 +928,7 @@ Trait core.sectorCapitalDesignation {
 
 	techLevelAdj: { value:5.0	op:min }
 
-	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of the capital or a sector capital in order to participate in the imperial economy."
+	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of a capital in order to participate in the imperial economy. Under the Fire and Movement doctrine, capitals have jump beacons which allow friendly jumpship fleets to navigate to destinations within 250 light-years."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons
@@ -964,7 +964,7 @@ Trait core.sectorCapitalLawAndOrderDesignation {
 
 	techLevelAdj: { value:5.0	op:min }
 
-	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of the capital or a sector capital in order to participate in the imperial economy."
+	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of a capital in order to participate in the imperial economy."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons
@@ -1002,7 +1002,7 @@ Trait core.sectorCapitalStarshipDesignation {
 
 	techLevelAdj: { value:5.0	op:min }
 
-	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of the capital or a sector capital in order to participate in the imperial economy."
+	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of a capital in order to participate in the imperial economy."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons
@@ -1041,7 +1041,7 @@ Trait core.sectorCapitalTradeDesignation {
 
 	techLevelAdj: { value:5.0	op:min }
 
-	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of the capital or a sector capital in order to participate in the imperial economy."
+	description: "A sector capital helps with the administration of the empire. Every imperial world must be within 250 light-years of a capital in order to participate in the imperial economy. Under the Trade and Enterprise doctrine, capitals function as trading hubs and can sell resources to Mesophon Traders Union planets."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons
@@ -1075,7 +1075,7 @@ Trait core.tradingHubDesignation {
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
-	description: "A trading hub allows you to trade with other empires and to move any resource between worlds."
+	description: "A trading hub allows an empire to move resources between worlds."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons

--- a/Core.ars
+++ b/Core.ars
@@ -481,7 +481,7 @@ Trait core.starport {
 	minTechLevel: 5
 	destroysTo: (core.spaceport)
 	
-	esignationOnly: true
+	designationOnly: true
 	workingConditions: 7
 
 	description: "A starport is an upgraded spaceport that supports inter-empire trade."

--- a/Core.ars
+++ b/Core.ars
@@ -237,7 +237,7 @@ Trait core.pressurizedHabitat {
 
 	workingConditions: 6
 
-	description: "A pressurized habit is an upgrade to a life support system. A pressurized habitat allows a larger population to survive on a barren world."
+	description: "A pressurized habitat is an upgrade to a life support system. A pressurized habitat allows a larger population to survive on a barren world."
 	}
 
 Trait core.pressurizedHabitatRuins {

--- a/CoreEnvironment.ars
+++ b/CoreEnvironment.ars
@@ -445,6 +445,8 @@ Trait core.fieryWorld
 	radius: 0.75
 
 	impartTraits: (
+		core.environmentFiery
+
 		{	type:table
 			value: (
 				(60		core.chronimiumRare)
@@ -486,35 +488,6 @@ Trait core.fieryWorld
 
 		op:defaultValue
 		}
-
-	consumption: (
-		{	type: core.radiationShielding	//	Item to consume
-			minTechLevel: 3					//	Only consume if world is this tech or higher
-			
-			amount: {
-				type:byTechAndPopulation
-				value: (
-					(atomic				0.06)
-					(digital			0.08)
-					(spacefaring		0.10)
-					(fusion				0.12)
-					(biotech			0.15)
-					(antimatter			0.19)
-					(quantum			0.24)
-					(postIndustrial		0.30)
-					)
-				}
-
-			consequences: (
-				{	demandMet: 1.0
-					deathRate: 0.01			//	1% killed if 100% of demand fails
-					revIndex: 100
-					techRegress: 0.25
-					efficiencyAdj: 0.95
-					}
-				)
-			}
-		)
 
 	techLevelAdj: { value:3.0	op:min }
 
@@ -849,6 +822,8 @@ Trait core.transuranicWorld
 	radius: 1.0
 
 	impartTraits: (
+		core.environmentRadioactive
+
 		{	type:table
 			value: (
 				(60		core.chronimiumCommon)
@@ -890,35 +865,6 @@ Trait core.transuranicWorld
 
 		op:defaultValue
 		}
-
-	consumption: (
-		{	type: core.radiationMeds		//	Item to consume
-			minTechLevel: 3					//	Only consume if world is this tech or higher
-			
-			amount: {
-				type:byTechAndPopulation
-				value: (
-					(atomic				0.06)
-					(digital			0.08)
-					(spacefaring		0.10)
-					(fusion				0.12)
-					(biotech			0.15)
-					(antimatter			0.19)
-					(quantum			0.24)
-					(postIndustrial		0.30)
-					)
-				}
-
-			consequences: (
-				{	demandMet: 1.0
-					deathRate: 0.01			//	1% killed if 100% of demand fails
-					revIndex: 100
-					techRegress: 0.25
-					efficiencyAdj: 0.95
-					}
-				)
-			}
-		)
 
 	techLevelAdj: { value:3.0	op:min }
 
@@ -1654,6 +1600,42 @@ Trait core.earthLikeBiosphere
 			}
 		)
 
+	hidden: true
+	}
+
+Trait core.environmentFiery
+	{
+	category: feature
+	name: "fiery environment"
+
+	consumption: (
+		{	type: core.radiationShielding	//	Item to consume
+			minTechLevel: 3					//	Only consume if world is this tech or higher
+			
+			amount: {
+				type:byTechAndPopulation
+				value: (
+					(atomic				0.06)
+					(digital			0.08)
+					(spacefaring		0.10)
+					(fusion				0.12)
+					(biotech			0.15)
+					(antimatter			0.19)
+					(quantum			0.24)
+					(postIndustrial		0.30)
+					)
+				}
+
+			consequences: (
+				{	demandMet: 1.0
+					deathRate: 0.01			//	1% killed if 100% of demand fails
+					revIndex: 100
+					techRegress: 0.25
+					efficiencyAdj: 0.95
+					}
+				)
+			}
+		)
 	hidden: true
 	}
 

--- a/CoreGroundUnits.ars
+++ b/CoreGroundUnits.ars
@@ -242,7 +242,7 @@ Trait core.imperialSecurityService {
 
 Trait core.militiaBase {
 	name: "militia base"
-	category: industry
+	category: improvement
 	role: academyIndustry
 
 	production: (core.infantry)

--- a/CoreJumpships.ars
+++ b/CoreJumpships.ars
@@ -50,6 +50,7 @@ Trait core.jumpshipYardsDesignation {
 		{ type:core.trillumExtractor alloc:demand }
 
 		{ type:core.imperialAdministration alloc:demand }
+		{ type:core.jumpBeaconStructure alloc:demand}		
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
@@ -384,7 +385,6 @@ Trait core.fleetBase {
 	name: "fleet base"
 	category: industry
 	role: shipyardIndustry
-	inheritFrom: (core.jumpBeaconAttribute)
 
 	production: (
 		core.infantry 
@@ -407,7 +407,6 @@ Trait core.fleetHQ {
 	name: "fleet HQ"
 	category: industry
 	role: shipyardIndustry
-	inheritFrom: (core.jumpBeaconAttribute)
 
 	production: (
 		core.infantry 
@@ -449,7 +448,6 @@ Trait core.jumpshipYards {
 	name: "jumpship yards"
 	category: industry
 	role: shipyardIndustry
-	inheritFrom: (core.jumpBeaconAttribute)
 
 	production: (
 		core.explorerVanguard

--- a/CoreJumpships.ars
+++ b/CoreJumpships.ars
@@ -54,7 +54,7 @@ Trait core.jumpshipYardsDesignation {
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
-	description: "Jumpship yards build jumpships, which are fast but weaker than starships."
+	description: "A jumpship yards builds jumpships, which are fast but weaker than starships. The yards' jump beacon allows friendly jumpship fleets to navigate to destinations within 250 light-years."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons

--- a/CoreRamships.ars
+++ b/CoreRamships.ars
@@ -59,7 +59,7 @@ Trait core.ramshipYardsDesignation {
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
-	description: "Ramjet yards build ramjets, which use nebular gas for propulsion."
+	description: "A ramjet yards builds ramjets, which use nebular gas for propulsion."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons

--- a/CoreStarships.ars
+++ b/CoreStarships.ars
@@ -55,7 +55,7 @@ Trait core.starshipYardsDesignation {
 		{ type:core.consumerGoodsAutofac alloc:demand }
 		)
 
-	description: "Starship yards build starships, which are powerful but slow."
+	description: "A starship yards builds starships, which are powerful but slow."
 
 	imageMedium: { type:constant
 		resource: core.designationIcons


### PR DESCRIPTION
**Major changes:**
Partial implementation of [Ministry ticket 78996](http://ministry.kronosaur.com/record.hexm?id=78996):
- jumpBeacon attribute is now an attribute of a new standalone designationOnly structures on yards / appropriate sector capitals (previously it was an attribute of the fleetHQ or yards structure)
- jump beacon structure takes 12 periods to come online on yards / sector capitals (hopefully jump beacon behavior respects buildTime, similar to sector capital administration)

This addresses the "vagueness" and "reduced strategic complexity" issues. It does not address the spite-redesignation issue, and it does not implement beacon structures as buildable anywhere or subject to a spacing requirement (the "even better solution" described in the ticket).

[Ministry ticket 75554](http://ministry.kronosaur.com/record.hexm?id=75554):
- T&E doctrine gets jump beacons on imperial capital and sector capitals, so that T&E players are not obligated to build yards in order to use purchased jumpships.

**Minor changes:**
- fixed typo in pressurized habitat
- changed some designation descriptions to be more explicit about functionality
- [Ministry ticket 59152](http://ministry.kronosaur.com/record.hexm?id=59152): when a planet with a starport gets redesignated, it should get a spaceport. This is accomplished by having the starport ruin to a spaceport.
- standardized how fiery and transuranic worlds implement planetary environment
- [Ministry ticket 71071](https://ministry.kronosaur.com/record.hexm?id=71071): militia base should not disappear when zero labor is allocated. Accomplished by making it category:improvement, rather than category:industry.